### PR TITLE
fix ldap findByUserIds error (#1910)

### DIFF
--- a/apollo-portal/src/main/java/com/ctrip/framework/apollo/portal/spi/ldap/LdapUserService.java
+++ b/apollo-portal/src/main/java/com/ctrip/framework/apollo/portal/spi/ldap/LdapUserService.java
@@ -84,10 +84,9 @@ public class LdapUserService implements UserService {
     if (CollectionUtils.isEmpty(userIds)) {
       return null;
     } else {
-      ContainerCriteria criteria = ldapQueryCriteria()
-          .and(query().where(loginIdAttrName).is(userIds.get(0)));
+      ContainerCriteria criteria = query().where(loginIdAttrName).is(userIds.get(0));
       userIds.stream().skip(1).forEach(userId -> criteria.or(loginIdAttrName).is(userId));
-      return ldapTemplate.search(criteria, ldapUserInfoMapper);
+      return ldapTemplate.search(ldapQueryCriteria().and(criteria), ldapUserInfoMapper);
     }
   }
 


### PR DESCRIPTION
Fix the issue 'Container type has already been specified as AND, cannot change it to OR'